### PR TITLE
Split fixtures and unit tests due to long time to run

### DIFF
--- a/.github/workflows/ratchet.yaml
+++ b/.github/workflows/ratchet.yaml
@@ -16,8 +16,8 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version-file: "go.mod"
-      - name: Tests
-        run: go test ./...
+      - name: Test
+        run: go test ./... --tags=fixtures
         working-directory: ratchet
       - name: Race detection
         run: go test -race ./...

--- a/ratchet/Makefile
+++ b/ratchet/Makefile
@@ -7,3 +7,7 @@ schemata/%.json.zst:
 
 build/%.json: schemata/%.json.zst
 	zstdcat "$^" >"$@"
+
+.PHONY: test
+test:
+	act --rm -C ../

--- a/ratchet/ratchet.go
+++ b/ratchet/ratchet.go
@@ -11,6 +11,22 @@ import (
 	"github.com/tidwall/gjson"
 )
 
+func Main() int {
+	if len(os.Args) < 3 {
+		fmt.Fprintf(os.Stderr, "Usage: %s [terraform-provider-schema.json] [provider_address]\n", os.Args[0])
+		return 1
+	}
+	JSONData, err := os.ReadFile(os.Args[1])
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	CUESchema := EmitEntities(os.Args[2], JSONData)
+	ctx := cuecontext.New()
+	fmt.Printf("%#v\n", ctx.CompileString(CUESchema))
+	return 0
+}
+
 func formatPrimitiveTypes(key, value string, typeAttributes gjson.Result) string {
 	var output string
 	switch {
@@ -233,20 +249,4 @@ func EmitEntities(providerID string, JSONData []byte) string {
 		return true
 	})
 	return strings.Join(output, "\n")
-}
-
-func Main() int {
-	if len(os.Args) < 3 {
-		fmt.Fprintf(os.Stderr, "Usage: %s [terraform-provider-schema.json] [provider_address]\n", os.Args[0])
-		return 1
-	}
-	JSONData, err := os.ReadFile(os.Args[1])
-	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		return 1
-	}
-	CUESchema := EmitEntities(os.Args[2], JSONData)
-	ctx := cuecontext.New()
-	fmt.Printf("%#v\n", ctx.CompileString(CUESchema))
-	return 0
 }

--- a/ratchet/ratchet_fixtures_test.go
+++ b/ratchet/ratchet_fixtures_test.go
@@ -1,0 +1,16 @@
+//go:build fixtures
+
+package ratchet_test
+
+import (
+	"testing"
+
+	"github.com/rogpeppe/go-internal/testscript"
+)
+
+func TestRatchet(t *testing.T) {
+	testscript.Run(t, testscript.Params{
+		Dir: "testdata/script/fixtures",
+		// UpdateScripts: true,
+	})
+}

--- a/ratchet/ratchet_test.go
+++ b/ratchet/ratchet_test.go
@@ -22,13 +22,6 @@ func TestRatchetEmitDataSourcesEntities(t *testing.T) {
 	})
 }
 
-func TestRatchet(t *testing.T) {
-	testscript.Run(t, testscript.Params{
-		Dir: "testdata/script/fixtures",
-		// UpdateScripts: true,
-	})
-}
-
 func TestMain(m *testing.M) {
 	os.Exit(testscript.RunMain(m, map[string]func() int{
 		"ratchet": ratchet.Main,


### PR DESCRIPTION
The fixtures test takes about 2s to run which is not ideal for TDD in Go. Hence, I'm isolating the fixtures tests using a tag called fixtures.

Also, This PR adds a phony make command called test which runs act locally. It's useful to test changes in the GitHub workflow before pushing it.